### PR TITLE
Remove build directory before unzipping a new artifact

### DIFF
--- a/.github/workflows/deploy-mac.yml
+++ b/.github/workflows/deploy-mac.yml
@@ -85,6 +85,7 @@ jobs:
             export PATH="/usr/local/bin/:$PATH" # aws command path
             pwd 
             aws s3 cp --profile marcel-ourcompanylunch --region ap-northeast-2 s3://${{ vars.S3_BUCKET_NAME }}/$FILENAME.zip ./$FILENAME.zip
+            rm -r ~/web/ourcompanylunch/build
             unzip -o -q $FILENAME.zip -d ~/web/ourcompanylunch/
             cd ~/web/ourcompanylunch
             scripts/startup_in_mac.sh


### PR DESCRIPTION
### Changes

<!-- Describe what changed in this PR. -->

**AS-IS**
- Don't remove remaining build jar file during ci/cd.
- If build filename becomes different, this is a problem because old jar file remains.

**TO-BE**
- Remove remaining build jar file before unzipping a new artifact.

Resolves #60 