### PR TITLE
Give ids in response

### DIFF
--- a/src/main/java/com/marceldev/ourcompanylunch/controller/CommentController.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.marceldev.ourcompanylunch.controller;
 
 import com.marceldev.ourcompanylunch.dto.comment.CommentOutputDto;
 import com.marceldev.ourcompanylunch.dto.comment.CreateCommentDto;
+import com.marceldev.ourcompanylunch.dto.comment.CreateCommentDto.Response;
 import com.marceldev.ourcompanylunch.dto.comment.GetCommentListDto;
 import com.marceldev.ourcompanylunch.dto.comment.UpdateCommentDto;
 import com.marceldev.ourcompanylunch.service.CommentService;
@@ -36,13 +37,13 @@ public class CommentController {
           + "Also enter a sharing option."
   )
   @PostMapping("/diners/{id}/comments")
-  public ResponseEntity<Void> createComment(
+  public ResponseEntity<CreateCommentDto.Response> createComment(
       @PathVariable long id,
-      @Validated @RequestBody CreateCommentDto createCommentDto
+      @Validated @RequestBody CreateCommentDto.Request dto
   ) {
-    commentService.createComment(id, createCommentDto);
-    messageProducerService.produceForDinerSubscribers(id, createCommentDto.getContent());
-    return ResponseEntity.ok().build();
+    Response response = commentService.createComment(id, dto);
+    messageProducerService.produceForDinerSubscribers(id, dto.getContent());
+    return ResponseEntity.ok(response);
   }
 
   @Operation(

--- a/src/main/java/com/marceldev/ourcompanylunch/controller/CompanyController.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/controller/CompanyController.java
@@ -3,6 +3,7 @@ package com.marceldev.ourcompanylunch.controller;
 import com.marceldev.ourcompanylunch.dto.company.ChooseCompanyDto;
 import com.marceldev.ourcompanylunch.dto.company.CompanyOutputDto;
 import com.marceldev.ourcompanylunch.dto.company.CreateCompanyDto;
+import com.marceldev.ourcompanylunch.dto.company.CreateCompanyDto.Response;
 import com.marceldev.ourcompanylunch.dto.company.GetCompanyListDto;
 import com.marceldev.ourcompanylunch.dto.company.UpdateCompanyDto;
 import com.marceldev.ourcompanylunch.dto.error.ErrorResponse;
@@ -44,11 +45,11 @@ public class CompanyController {
       @ApiResponse(responseCode = "400", description = "errorCode: 2001 - A company with same name exists.")
   })
   @PostMapping("/companies")
-  public ResponseEntity<Void> createCompany(
-      @Validated @RequestBody CreateCompanyDto createCompanyDto
+  public ResponseEntity<CreateCompanyDto.Response> createCompany(
+      @Validated @RequestBody CreateCompanyDto.Request createCompanyDto
   ) {
-    companyService.createCompany(createCompanyDto);
-    return ResponseEntity.ok().build();
+    Response response = companyService.createCompany(createCompanyDto);
+    return ResponseEntity.ok(response);
   }
 
   @Operation(

--- a/src/main/java/com/marceldev/ourcompanylunch/controller/DinerController.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/controller/DinerController.java
@@ -2,6 +2,7 @@ package com.marceldev.ourcompanylunch.controller;
 
 import com.marceldev.ourcompanylunch.dto.diner.AddDinerTagsDto;
 import com.marceldev.ourcompanylunch.dto.diner.CreateDinerDto;
+import com.marceldev.ourcompanylunch.dto.diner.CreateDinerDto.Response;
 import com.marceldev.ourcompanylunch.dto.diner.DinerDetailOutputDto;
 import com.marceldev.ourcompanylunch.dto.diner.DinerOutputDto;
 import com.marceldev.ourcompanylunch.dto.diner.GetDinerListDto;
@@ -46,11 +47,11 @@ public class DinerController {
       summary = "Register a diner"
   )
   @PostMapping("/diners")
-  public ResponseEntity<Void> createDiner(
-      @Validated @RequestBody CreateDinerDto createDinerDto
+  public ResponseEntity<CreateDinerDto.Response> createDiner(
+      @Validated @RequestBody CreateDinerDto.Request dto
   ) {
-    dinerService.createDiner(createDinerDto);
-    return ResponseEntity.ok().build();
+    Response response = dinerService.createDiner(dto);
+    return ResponseEntity.ok(response);
   }
 
   @Operation(

--- a/src/main/java/com/marceldev/ourcompanylunch/controller/ReplyController.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/controller/ReplyController.java
@@ -1,6 +1,7 @@
 package com.marceldev.ourcompanylunch.controller;
 
 import com.marceldev.ourcompanylunch.dto.reply.CreateReplyDto;
+import com.marceldev.ourcompanylunch.dto.reply.CreateReplyDto.Response;
 import com.marceldev.ourcompanylunch.dto.reply.GetReplyListDto;
 import com.marceldev.ourcompanylunch.dto.reply.ReplyOutputDto;
 import com.marceldev.ourcompanylunch.dto.reply.UpdateReplyDto;
@@ -32,12 +33,12 @@ public class ReplyController {
       description = "A member can write a reply on the comment."
   )
   @PostMapping("/comments/{id}/replies")
-  public ResponseEntity<Void> createReply(
+  public ResponseEntity<CreateReplyDto.Response> createReply(
       @PathVariable long id,
-      @Validated @RequestBody CreateReplyDto createReplyDto
+      @Validated @RequestBody CreateReplyDto.Request dto
   ) {
-    replyService.createReply(id, createReplyDto);
-    return ResponseEntity.ok().build();
+    Response response = replyService.createReply(id, dto);
+    return ResponseEntity.ok(response);
   }
 
   @Operation(

--- a/src/main/java/com/marceldev/ourcompanylunch/dto/comment/CreateCommentDto.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/dto/comment/CreateCommentDto.java
@@ -6,15 +6,25 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 
-@Data
-@Builder
 public class CreateCommentDto {
 
-  @NotNull
-  @Schema(example = "It's delicious")
-  private String content;
+  @Data
+  @Builder
+  public static class Request {
 
-  @NotNull
-  @Schema(example = "COMPANY", allowableValues = {"COMPANY", "ME"})
-  private ShareStatus shareStatus;
+    @NotNull
+    @Schema(example = "It's delicious")
+    private String content;
+
+    @NotNull
+    @Schema(example = "COMPANY", allowableValues = {"COMPANY", "ME"})
+    private ShareStatus shareStatus;
+  }
+
+  @Data
+  @Builder
+  public static class Response {
+
+    private final long id;
+  }
 }

--- a/src/main/java/com/marceldev/ourcompanylunch/dto/company/CreateCompanyDto.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/dto/company/CreateCompanyDto.java
@@ -4,43 +4,55 @@ import com.marceldev.ourcompanylunch.entity.Company;
 import com.marceldev.ourcompanylunch.util.LocationUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@Data
-@Builder
 public class CreateCompanyDto {
 
-  @NotNull
-  @Schema(example = "HelloCompany")
-  private String name;
+  @Data
+  @Builder
+  public static class Request {
 
-  @NotNull
-  @Schema(example = "123, Gangnam-daero Gangnam-gu Seoul")
-  private String address;
+    @NotNull
+    @Schema(example = "HelloCompany")
+    private String name;
 
-  @Schema(example = "company123")
-  private String enterKey;
+    @NotNull
+    @Schema(example = "123, Gangnam-daero Gangnam-gu Seoul")
+    private String address;
 
-  @NotNull
-  @Schema(example = "false")
-  private Boolean enterKeyEnabled;
+    @Schema(example = "company123")
+    private String enterKey;
 
-  @NotNull
-  @Schema(example = "37.5665")
-  private double latitude;
+    @NotNull
+    @Schema(example = "false")
+    private Boolean enterKeyEnabled;
 
-  @NotNull
-  @Schema(example = "126.9780")
-  private double longitude;
+    @NotNull
+    @Schema(example = "37.5665")
+    private double latitude;
 
-  public Company toEntity() {
-    return Company.builder()
-        .name(name)
-        .address(address)
-        .enterKey(enterKey)
-        .enterKeyEnabled(enterKeyEnabled)
-        .location(LocationUtil.createPoint(longitude, latitude))
-        .build();
+    @NotNull
+    @Schema(example = "126.9780")
+    private double longitude;
+
+    public Company toEntity() {
+      return Company.builder()
+          .name(name)
+          .address(address)
+          .enterKey(enterKey)
+          .enterKeyEnabled(enterKeyEnabled)
+          .location(LocationUtil.createPoint(longitude, latitude))
+          .build();
+    }
+  }
+
+  @Data
+  @Builder
+  public static class Response {
+    private final long id;
   }
 }

--- a/src/main/java/com/marceldev/ourcompanylunch/dto/company/CreateCompanyDto.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/dto/company/CreateCompanyDto.java
@@ -4,11 +4,8 @@ import com.marceldev.ourcompanylunch.entity.Company;
 import com.marceldev.ourcompanylunch.util.LocationUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 public class CreateCompanyDto {
 
@@ -53,6 +50,7 @@ public class CreateCompanyDto {
   @Data
   @Builder
   public static class Response {
+
     private final long id;
   }
 }

--- a/src/main/java/com/marceldev/ourcompanylunch/dto/diner/CreateDinerDto.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/dto/diner/CreateDinerDto.java
@@ -9,36 +9,46 @@ import java.util.LinkedHashSet;
 import lombok.Builder;
 import lombok.Data;
 
-@Data
-@Builder
 public class CreateDinerDto {
 
-  @NotNull
-  @Schema(example = "Gamsung Taco")
-  private String name;
+  @Data
+  @Builder
+  public static class Request {
 
-  @NotNull
-  @Schema(example = "https://link.me/FeOCTkYP", requiredMode = RequiredMode.NOT_REQUIRED)
-  private String link;
+    @NotNull
+    @Schema(example = "Gamsung Taco")
+    private String name;
 
-  @NotNull
-  @Schema(example = "37.4989021")
-  private double latitude;
+    @NotNull
+    @Schema(example = "https://link.me/FeOCTkYP", requiredMode = RequiredMode.NOT_REQUIRED)
+    private String link;
 
-  @NotNull
-  @Schema(example = "127.0276099")
-  private double longitude;
+    @NotNull
+    @Schema(example = "37.4989021")
+    private double latitude;
 
-  @NotNull
-  @Schema(example = "[\"Mexico\", \"Gamsung\"]")
-  private LinkedHashSet<String> tags;
+    @NotNull
+    @Schema(example = "127.0276099")
+    private double longitude;
 
-  public Diner toEntity() {
-    return Diner.builder()
-        .name(name)
-        .link(link)
-        .location(LocationUtil.createPoint(longitude, latitude))
-        .tags(tags)
-        .build();
+    @NotNull
+    @Schema(example = "[\"Mexico\", \"Gamsung\"]")
+    private LinkedHashSet<String> tags;
+
+    public Diner toEntity() {
+      return Diner.builder()
+          .name(name)
+          .link(link)
+          .location(LocationUtil.createPoint(longitude, latitude))
+          .tags(tags)
+          .build();
+    }
+  }
+
+  @Data
+  @Builder
+  public static class Response {
+
+    private final long id;
   }
 }

--- a/src/main/java/com/marceldev/ourcompanylunch/dto/reply/CreateReplyDto.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/dto/reply/CreateReplyDto.java
@@ -6,15 +6,25 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 
-@Data
-@Builder
 public class CreateReplyDto {
 
-  @NotNull
-  @Schema(example = "I'll try")
-  private String content;
+  @Data
+  @Builder
+  public static class Request {
 
-  public CreateReplyDto(@JsonProperty("content") String content) {
-    this.content = content;
+    @NotNull
+    @Schema(example = "I'll try")
+    private String content;
+
+    public Request(@JsonProperty("content") String content) {
+      this.content = content;
+    }
+  }
+
+  @Data
+  @Builder
+  public static class Response {
+
+    private final long id;
   }
 }

--- a/src/main/java/com/marceldev/ourcompanylunch/service/CommentService.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/service/CommentService.java
@@ -33,7 +33,7 @@ public class CommentService {
   private final MemberRepository memberRepository;
 
   @Transactional
-  public void createComment(long dinerId, CreateCommentDto dto) {
+  public CreateCommentDto.Response createComment(long dinerId, CreateCommentDto.Request dto) {
     Member member = getMember();
 
     Diner diner = dinerRepository.findById(dinerId)
@@ -47,7 +47,8 @@ public class CommentService {
         .member(member)
         .build();
 
-    commentRepository.save(comment);
+    comment = commentRepository.save(comment);
+    return CreateCommentDto.Response.builder().id(comment.getId()).build();
   }
 
   public Page<CommentOutputDto> getCommentList(long dinerId,

--- a/src/main/java/com/marceldev/ourcompanylunch/service/CompanyService.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/service/CompanyService.java
@@ -46,13 +46,12 @@ public class CompanyService {
   private final EmailSender emailSender;
 
   @Transactional
-  public void createCompany(CreateCompanyDto dto) {
+  public CreateCompanyDto.Response createCompany(CreateCompanyDto.Request dto) {
     if (companyRepository.existsCompanyByName(dto.getName())) {
       throw new SameCompanyNameExistException();
     }
-    Company company = dto.toEntity();
-
-    companyRepository.save(company);
+    Company company = companyRepository.save(dto.toEntity());
+    return CreateCompanyDto.Response.builder().id(company.getId()).build();
   }
 
   @Transactional

--- a/src/main/java/com/marceldev/ourcompanylunch/service/DinerService.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/service/DinerService.java
@@ -51,11 +51,12 @@ public class DinerService {
   private final DinerSubscriptionRepository dinerSubscriptionRepository;
 
   @Transactional
-  public void createDiner(CreateDinerDto createDinerDto) {
+  public CreateDinerDto.Response createDiner(CreateDinerDto.Request dto) {
     Company company = getCompany();
-    Diner diner = createDinerDto.toEntity();
+    Diner diner = dto.toEntity();
     diner.setCompany(company);
-    dinerRepository.save(diner);
+    diner = dinerRepository.save(diner);
+    return CreateDinerDto.Response.builder().id(diner.getId()).build();
   }
 
   public Page<DinerOutputDto> getDinerList(GetDinerListDto dto) {

--- a/src/main/java/com/marceldev/ourcompanylunch/service/ReplyService.java
+++ b/src/main/java/com/marceldev/ourcompanylunch/service/ReplyService.java
@@ -39,7 +39,7 @@ public class ReplyService {
   private final CompanyRepository companyRepository;
 
   @Transactional
-  public void createReply(long commentId, CreateReplyDto dto) {
+  public CreateReplyDto.Response createReply(long commentId, CreateReplyDto.Request dto) {
     checkDinerByCommentId(commentId);
 
     Member member = getMember();
@@ -53,7 +53,8 @@ public class ReplyService {
         .member(member)
         .build();
 
-    replyRepository.save(reply);
+    reply = replyRepository.save(reply);
+    return CreateReplyDto.Response.builder().id(reply.getId()).build();
   }
 
   public Page<ReplyOutputDto> getReplyList(long commentId, GetReplyListDto dto) {

--- a/src/test/java/com/marceldev/ourcompanylunch/service/CommentServiceTest.java
+++ b/src/test/java/com/marceldev/ourcompanylunch/service/CommentServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.marceldev.ourcompanylunch.dto.comment.CommentOutputDto;
 import com.marceldev.ourcompanylunch.dto.comment.CreateCommentDto;
+import com.marceldev.ourcompanylunch.dto.comment.CreateCommentDto.Response;
 import com.marceldev.ourcompanylunch.dto.comment.GetCommentListDto;
 import com.marceldev.ourcompanylunch.dto.comment.UpdateCommentDto;
 import com.marceldev.ourcompanylunch.entity.Comment;
@@ -117,22 +118,33 @@ class CommentServiceTest {
   @DisplayName("Create comment - Success")
   void create_comment() {
     //given
-    CreateCommentDto dto = CreateCommentDto.builder()
+    CreateCommentDto.Request dto = CreateCommentDto.Request.builder()
         .content("It's delicious")
         .shareStatus(ShareStatus.COMPANY)
         .build();
     String email = "jack@example.com";
+    Comment comment = Comment.builder()
+        .id(100L)
+        .content("It's delicious")
+        .shareStatus(ShareStatus.COMPANY)
+        .member(member1)
+        .diner(diner1)
+        .build();
+
+    //when
     when(memberRepository.findByEmail(email))
         .thenReturn(Optional.of(member1));
     when(dinerRepository.findById(1L))
         .thenReturn(Optional.of(diner1));
+    when(commentRepository.save(any(Comment.class)))
+        .thenReturn(comment);
 
-    //when
-    commentService.createComment(1L, dto);
+    Response response = commentService.createComment(1L, dto);
     ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
 
     //then
     verify(commentRepository).save(captor.capture());
+    assertEquals(100L, response.getId());
     assertEquals("It's delicious", captor.getValue().getContent());
     assertEquals(ShareStatus.COMPANY, captor.getValue().getShareStatus());
     assertEquals(member1, captor.getValue().getMember());
@@ -143,7 +155,7 @@ class CommentServiceTest {
   @DisplayName("Create comment - Fail(Member not found)")
   void create_comment_fail_member_not_found() {
     //given
-    CreateCommentDto dto = CreateCommentDto.builder()
+    CreateCommentDto.Request dto = CreateCommentDto.Request.builder()
         .content("It's delicious")
         .shareStatus(ShareStatus.COMPANY)
         .build();
@@ -161,7 +173,7 @@ class CommentServiceTest {
   @DisplayName("Create comment - Fail(Diner not found)")
   void create_comment_fail_diner_not_found() {
     //given
-    CreateCommentDto dto = CreateCommentDto.builder()
+    CreateCommentDto.Request dto = CreateCommentDto.Request.builder()
         .content("It's delicious")
         .shareStatus(ShareStatus.COMPANY)
         .build();

--- a/src/test/java/com/marceldev/ourcompanylunch/service/CompanyServiceTest.java
+++ b/src/test/java/com/marceldev/ourcompanylunch/service/CompanyServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/marceldev/ourcompanylunch/service/DinerServiceTest.java
+++ b/src/test/java/com/marceldev/ourcompanylunch/service/DinerServiceTest.java
@@ -146,7 +146,7 @@ class DinerServiceTest {
         .longitude(127.39232323)
         .tags(tags)
         .build();
-    
+
     Diner savedDiner = Diner.builder()
         .id(100L)
         .name("Gamsung Taco")


### PR DESCRIPTION
### Changes

<!-- Describe what changed in this PR. -->

**AS-IS**
- When creating company, diner, comment, reply, success response is void.

**TO-BE**
- When creating company, diner, comment, reply, success response gives id of the entity.

### Test

<!-- Describe how this change is tested. --> 

- [x] Unit Test

- [x] API Test
  - POST /companies
  - POST /diners
  - POST /diners/{id}/comments
  - POST /comments/{id}/replies
